### PR TITLE
Removes paralist package

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -17,7 +17,6 @@
 \usepackage[pdftex,bookmarks=true,plainpages=false,pdfpagelabels=true]{hyperref}
 \usepackage{mdwlist}
 \usepackage{enumerate}
-\usepackage{paralist}
 \usepackage{array}
 \usepackage{longtable}
 \usepackage{listings}


### PR DESCRIPTION
This PR removes the `\usepackage{paralist}` command from `thesis.tex`.

The scenario and use case tables defined in `tex/use-case-table` don't render correctly if the `paralist` package is loaded.