### PR TITLE
Miscellaneous improvements

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -21,6 +21,7 @@
 \usepackage{longtable}
 \usepackage[utf8]{inputenc}
 \usepackage[capitalize, noabbrev]{cleveref}
+\usepackage{wasysym}
 
 % Path for graphics
 \graphicspath{{figures/}}
@@ -333,6 +334,12 @@ It contains a rationale of the selected storage scheme, file system or database,
 \section{Status}
 
 \textit{Note: Describe honestly the achieved goals (e.g. the well implemented and tested use cases) and the open goals here. if you only have achieved goals, you did something wrong in your analysis.}
+
+\begin{itemize}
+	\item [\Circle]
+	\item [\LEFTcircle]
+	\item [\CIRCLE]
+\end{itemize}
 
 \subsection{Realized Goals}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -14,7 +14,7 @@
 \usepackage{fancyhdr}
 \usepackage{color}
 \usepackage{booktabs}
-\usepackage[pdftex,bookmarks=true,plainpages=false,pdfpagelabels=true]{hyperref}
+\usepackage[pdftex,bookmarks=true,plainpages=false,pdfpagelabels=true]{hyperref}	%TODO make yourself familiar with \label, \ref and \hyperref for referencing figures, tables, chapters, etc.
 \usepackage{mdwlist}
 \usepackage{enumerate}
 \usepackage{array}

--- a/thesis.tex
+++ b/thesis.tex
@@ -19,7 +19,6 @@
 \usepackage{enumerate}
 \usepackage{array}
 \usepackage{longtable}
-\usepackage{listings}
 \usepackage[utf8]{inputenc}
 \usepackage[capitalize, noabbrev]{cleveref}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -54,7 +54,7 @@
 \newpage
 \thispagestyle{empty}
 \mbox{}
-\include{tex/disclaimer}
+\include{tex/disclaimer}		%TODO choose one of 'diploma | bachelor's | master's thesis' in the disclaimer file
 
 \newpage
 \thispagestyle{empty}

--- a/thesis.tex
+++ b/thesis.tex
@@ -219,16 +219,16 @@ Cite \cite{bruegge2004object} several times in this chapter.}
 
 \subsubsection{Visionary Scenarios}
 
-\textit{Note: Describe 1-2 visionary scenario here, i.e. a scenario that would perfectly solve your problem, even if it might not be realizable. use our scenario description template in form of free text description.}
+\textit{Note: Describe 1-2 visionary scenario here, i.e. a scenario that would perfectly solve your problem, even if it might not be realizable. Use our scenario description template (./tex/use-case-table.tex) in form of free text description.}
 
 \subsubsection{Demo Scenarios}
 
-\textit{Note: Describe 1-2 demo scenario here, i.e. a scenario that you can implement and demonstrate until the end of your thesis. use our scenario description template in form of free text description.}
+\textit{Note: Describe 1-2 demo scenario here, i.e. a scenario that you can implement and demonstrate until the end of your thesis. Use our scenario description template (./tex/use-case-table.tex) in form of free text description.}
 
 \subsection{Use Case Model}
 
 \textit{Note: This subsection should contain a UML Use Case Diagram including roles and their use cases. You can use colors to indicate priorities. Think about splitting the diagram into multiple ones if you have more than 10 use cases.
-\textbf{Important:} Make sure to describe the most important use cases using the use case table template. Also describe the rationale of the use case model, i.e. why you modeled it like you show it in the diagram.}
+\textbf{Important:} Make sure to describe the most important use cases using the use case table template (./tex/use-case-table.tex). Also describe the rationale of the use case model, i.e. why you modeled it like you show it in the diagram.}
 
 \subsection{Analysis Object Model}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -282,7 +282,7 @@ It contains a rationale of the selected storage scheme, file system or database,
 
 \section{Global Software Control}
 
-\textit{Note: Optional section describing describing the control flow of the system, in particular, whether a monolithic, event-driven control flow or concurrent processes have been selected, how requests are initiated and specific synchronization issues}
+\textit{Note: Optional section describing the control flow of the system, in particular, whether a monolithic, event-driven control flow or concurrent processes have been selected, how requests are initiated and specific synchronization issues}
 
 
 \section{Boundary Conditions}


### PR DESCRIPTION
I suggest reviewing commit by commit. The changes are:
- Removed a duplicated word
- Added a TODO that you have to choose your thesis type for the disclaimer
- Removed a duplicated `usepackage` (is already present in line 6)
- Added a TODO asking writers to familiarize themselves with using `hyperref`
- Added the location of the referenced template file (I didn't know this was part of the repository at first and looked on confluence...)
- Added `usepackage{wasysym}` and the commands usually used in the `Status` section:
![grafik](https://user-images.githubusercontent.com/72132281/114931405-7e573880-9e36-11eb-8c85-203bab2c0baa.png)
