### PR TITLE
Replace Placeholder for Pdf Metadata with Reference

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -40,10 +40,7 @@
 \def\date{(handover date)}		%TODO add submission / handover date
 
 
-\hypersetup{pdfborder={0 0 0},
-                        pdfauthor={<author>},
-                        pdftitle={<title english>},
-                        }
+\hypersetup{pdfborder={0 0 0}, pdfauthor={\author}, pdftitle={\title}}
 
 \lstset{showspaces=false, numbers=left, frame=single, basicstyle=\small}
 
@@ -355,7 +352,7 @@ It contains a rationale of the selected storage scheme, file system or database,
 
 \section{Future Work}
 
-\textit{Note: Tell us the next steps  (that you would do if you have more time. be creative, visionary and open-minded here.}
+\textit{Note: Tell us the next steps  (that you would do if you have more time). Be creative, visionary and open-minded here.}
 
 
 


### PR DESCRIPTION
### Description
Currently the pdf meta data uses a placeholder that needs to be filled in manually. This can be replaced with a reference to the already defined `\author` and `\title`, removing one step in customization and possible source of errors.

Since the command no longer requires editing, it can be compacted into one line.

Also fixes a typo.

### Steps for Testing
1. Change author data
2. Compile
3. The resulting pdf's author should also be changed