### PR TITLE
change main branch name

### DIFF
--- a/.github/workflows/build-release-thesis.yml
+++ b/.github/workflows/build-release-thesis.yml
@@ -3,14 +3,14 @@ name: Build and release thesis
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build_release_thesis:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
         with:
           fetch-depth: '0'
       - name: Create initial tag
@@ -20,7 +20,7 @@ jobs:
           fi
       - name: Bump version and push tag
         id: bump
-        uses: anothrNick/github-tag-action@master
+        uses: anothrNick/github-tag-action@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
@@ -36,7 +36,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Compile LaTeX document
-        uses: dante-ev/latex-action@master
+        uses: dante-ev/latex-action@main
         with:
           root_file: ./thesis.tex
       - name: Upload Release Asset


### PR DESCRIPTION
Changes the main branch name from master to main in order to follow the [guidelines for Inclusive, Diversity-Sensitive, and Appreciative Language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/?highlight=inclusive)

After merging this the main branch needs to be set in the settings in 
```
settings -> branches -> default branch
```