### PR TITLE
#20: Headers numbering in proposal

### DIFF
--- a/common/preamble.tex
+++ b/common/preamble.tex
@@ -1,7 +1,5 @@
 %% This file is shared between thesis and proposal
 
-\documentclass[a4paper,12pt,twoside]{report}
-
 \usepackage[scaled]{helvet}
 \usepackage{url}
 \usepackage{cite}

--- a/proposal.tex
+++ b/proposal.tex
@@ -1,3 +1,6 @@
+% Configure documentclass
+\documentclass[a4paper,12pt,twoside]{article}
+
 % Add common preamble to the document
 \input{common/preamble.tex}
 \def\proposal{Proposal for}
@@ -33,7 +36,7 @@
 
 %------- Start of Proposal -------
 \TODO{Before you start with your thesis, have a look at our guides on confluence! \url{https://confluence.ase.in.tum.de/display/EduResStud/How+to+thesis}}
-\section*{Introduction}
+\section{Introduction}
         \missing{ Introduction
                 \begin{itemize}
                         \item Introduce the reader to the general setting
@@ -42,7 +45,7 @@
                 \end{itemize}
         }
 
-\section*{Problem}
+\section{Problem}
         \missing{ Problem description
                 \begin{itemize}
                         \item What is/are the problem(s)? 
@@ -52,7 +55,7 @@
                 \end{itemize}
         }
         
-\section*{Motivation}
+\section{Motivation}
         \missing{ Thesis Motivation
                 \begin{itemize}
                         \item Outline why it is important to solve the problem
@@ -62,14 +65,14 @@
                 \end{itemize}
         }
         
-\section*{Objective}
+\section{Objective}
         \missing{ Thesis Objective
                 \begin{itemize}
                         \item What are the main goals of your thesis?
                 \end{itemize}
         }
         
-\section*{Schedule}
+\section{Schedule}
         \missing{ Thesis Schedule
                 \begin{itemize}
                         \item When will the thesis Start (Always 15th of Month) 

--- a/thesis.tex
+++ b/thesis.tex
@@ -1,3 +1,6 @@
+% Configure documentclass
+\documentclass[a4paper,12pt,twoside]{report}
+
 % Add common preamble to the document
 \input{common/preamble.tex}
 


### PR DESCRIPTION
### Motivation and Context
Fixes #20

### Description
Added `/documentclass` declaration directly to thesis and proposal. This way proposal can be article, which natively supports numbering

Steps for Testing
1. Build both documents using code from main
2. Build both documents using updated code
3. Verify that the only change is the numbering of headers in proposal